### PR TITLE
fix: prevent recursive animation application in styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -22,14 +22,13 @@ body {
     -webkit-mask-image: linear-gradient(90deg, transparent, #fff 20%, #fff 80%, transparent)
 }
 
-.scroll div {
+.scroll > div {
     white-space: nowrap;
     animation: scroll var(--time) linear infinite;
     animation-delay: calc(var(--time)*-1);
-
 }
 
-.scroll div:nth-child(2) {
+.scroll > div:nth-child(2) {
     animation: scroll2 var(--time) linear infinite;
     animation-delay: calc(var(--time)/-2);
 }


### PR DESCRIPTION
Fixed an issue where the animation was applied recursively to all nested div elements inside .scroll, causing unintended behavior. Now, the animation is restricted to direct child elements using the > selector